### PR TITLE
Add save inventory wrapper

### DIFF
--- a/bin/amazon-collector
+++ b/bin/amazon-collector
@@ -31,10 +31,5 @@ ingress_api_uri = URI(args[:ingress_api])
 TopologicalInventoryIngressApiClient.configure.scheme = ingress_api_uri.scheme || "http"
 TopologicalInventoryIngressApiClient.configure.host   = "#{ingress_api_uri.host}:#{ingress_api_uri.port}"
 
-loop do
-
-  collector = TopologicalInventory::Amazon::Collector.new(args[:source], args[:access_key_id], args[:secret_access_key])
-  collector.collect!
-
-  sleep(10)
-end
+collector = TopologicalInventory::Amazon::Collector.new(args[:source], args[:access_key_id], args[:secret_access_key])
+collector.collect!

--- a/lib/topological_inventory/amazon/collector.rb
+++ b/lib/topological_inventory/amazon/collector.rb
@@ -8,6 +8,7 @@ require "topological_inventory/amazon/parser"
 require "topological_inventory/amazon/iterator"
 require "topological_inventory/amazon/logging"
 require "topological_inventory-ingress_api-client"
+require "topological_inventory-ingress_api-client/inventory/saver"
 
 module TopologicalInventory
   module Amazon
@@ -104,7 +105,7 @@ module TopologicalInventory
       def save_inventory(collections, refresh_state_uuid = nil, refresh_state_part_uuid = nil)
         return if collections.empty?
 
-        ingress_api_client.save_inventory(
+        TopologicalInventoryIngressApiClient::Inventory::Saver.new(ingress_api_client, logger).save(
           :inventory => TopologicalInventoryIngressApiClient::Inventory.new(
             :name                    => "Amazon",
             :schema                  => TopologicalInventoryIngressApiClient::Schema.new(:name => "Default"),
@@ -117,7 +118,7 @@ module TopologicalInventory
       end
 
       def sweep_inventory(refresh_state_uuid, total_parts, sweep_scope)
-        ingress_api_client.save_inventory(
+        TopologicalInventoryIngressApiClient::Inventory::Saver.new(ingress_api_client, logger).save(
           :inventory => TopologicalInventoryIngressApiClient::Inventory.new(
             :name               => "Amazon",
             :schema             => TopologicalInventoryIngressApiClient::Schema.new(:name => "Default"),

--- a/lib/topological_inventory/amazon/collector.rb
+++ b/lib/topological_inventory/amazon/collector.rb
@@ -8,7 +8,7 @@ require "topological_inventory/amazon/parser"
 require "topological_inventory/amazon/iterator"
 require "topological_inventory/amazon/logging"
 require "topological_inventory-ingress_api-client"
-require "topological_inventory-ingress_api-client/inventory/saver"
+require "topological_inventory-ingress_api-client/save_inventory/saver"
 
 module TopologicalInventory
   module Amazon
@@ -32,9 +32,15 @@ module TopologicalInventory
       end
 
       def collect!
-        entity_types.each do |entity_type|
-          process_entity(entity_type)
+        loop do
+          entity_types.each do |entity_type|
+            process_entity(entity_type)
+          end
+
+          sleep(30)
         end
+      rescue => e
+        logger.error(e)
       end
 
       def stop
@@ -105,7 +111,7 @@ module TopologicalInventory
       def save_inventory(collections, refresh_state_uuid = nil, refresh_state_part_uuid = nil)
         return if collections.empty?
 
-        TopologicalInventoryIngressApiClient::Inventory::Saver.new(ingress_api_client, logger).save(
+        TopologicalInventoryIngressApiClient::SaveInventory::Saver.new(ingress_api_client, logger).save(
           :inventory => TopologicalInventoryIngressApiClient::Inventory.new(
             :name                    => "Amazon",
             :schema                  => TopologicalInventoryIngressApiClient::Schema.new(:name => "Default"),
@@ -118,7 +124,7 @@ module TopologicalInventory
       end
 
       def sweep_inventory(refresh_state_uuid, total_parts, sweep_scope)
-        TopologicalInventoryIngressApiClient::Inventory::Saver.new(ingress_api_client, logger).save(
+        TopologicalInventoryIngressApiClient::SaveInventory::Saver.new(ingress_api_client, logger).save(
           :inventory => TopologicalInventoryIngressApiClient::Inventory.new(
             :name               => "Amazon",
             :schema             => TopologicalInventoryIngressApiClient::Schema.new(:name => "Default"),


### PR DESCRIPTION
Wrapper is able to deal with temporary API server failures and
logs a proper log. The currenly logger error is in a wrong format.

Depends on:
- [ ] https://github.com/ManageIQ/topological_inventory-ingress_api-client-ruby/pull/32