### PR TITLE
Add metrics to the collector

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "manageiq-loggers", "~> 0.1.1"
 gem 'manageiq-messaging'
 gem "more_core_extensions"
 gem "optimist"
+gem "prometheus_exporter", "~> 0.4.5"
 gem "rake"
 gem "topological_inventory-ingress_api-client", :git => "https://github.com/ManageIQ/topological_inventory-ingress_api-client-ruby", :branch => "master"
 

--- a/bin/amazon-collector
+++ b/bin/amazon-collector
@@ -7,6 +7,7 @@ STDOUT.sync = true
 
 require "bundler/setup"
 require "topological_inventory/amazon/collector"
+require "topological_inventory/amazon/collector/application_metrics"
 
 def parse_args
   require 'optimist'
@@ -31,5 +32,10 @@ ingress_api_uri = URI(args[:ingress_api])
 TopologicalInventoryIngressApiClient.configure.scheme = ingress_api_uri.scheme || "http"
 TopologicalInventoryIngressApiClient.configure.host   = "#{ingress_api_uri.host}:#{ingress_api_uri.port}"
 
-collector = TopologicalInventory::Amazon::Collector.new(args[:source], args[:access_key_id], args[:secret_access_key])
-collector.collect!
+begin
+  metrics = TopologicalInventory::Amazon::Collector::ApplicationMetrics.new
+  collector = TopologicalInventory::Amazon::Collector.new(args[:source], args[:access_key_id], args[:secret_access_key])
+  collector.collect!
+ensure
+  metrics.stop_server
+end

--- a/lib/topological_inventory/amazon/collector/application_metrics.rb
+++ b/lib/topological_inventory/amazon/collector/application_metrics.rb
@@ -1,0 +1,43 @@
+require "prometheus_exporter"
+require "prometheus_exporter/server"
+require "prometheus_exporter/client"
+require 'prometheus_exporter/instrumentation'
+
+module TopologicalInventory
+  module Amazon
+    class Collector
+      class ApplicationMetrics
+        def initialize(port = 9394)
+          configure_server(port)
+          configure_metrics
+        end
+
+        def record_error
+          @errors_counter.observe(1)
+        end
+
+        def stop_server
+          @server.stop
+        end
+
+        private
+
+        def configure_server(port)
+          @server = PrometheusExporter::Server::WebServer.new(:port => port)
+          @server.start
+
+          PrometheusExporter::Client.default = PrometheusExporter::LocalClient.new(:collector => @server.collector)
+        end
+
+        def configure_metrics
+          PrometheusExporter::Instrumentation::Process.start
+
+          PrometheusExporter::Metric::Base.default_prefix = "topological_inventory_amazon_collector_"
+
+          @errors_counter = PrometheusExporter::Metric::Counter.new("errors_total", "total number of collector errors")
+          @server.collector.register_metric(@errors_counter)
+        end
+      end
+    end
+  end
+end

--- a/spec/application_metrics_spec.rb
+++ b/spec/application_metrics_spec.rb
@@ -1,0 +1,27 @@
+require "topological_inventory/amazon/collector/application_metrics"
+require "active_support/core_ext/string"
+require "net/http"
+
+RSpec.describe TopologicalInventory::Amazon::Collector::ApplicationMetrics do
+  subject! { described_class.new(9394) }
+  after    { subject.stop_server }
+
+  it "exposes metrics" do
+    subject.record_error
+    subject.record_error
+
+    metrics = get_metrics
+    expect(metrics["topological_inventory_amazon_collector_errors_total"]).to eq("2")
+  end
+
+  def get_metrics
+    metrics = Net::HTTP.get(URI("http://localhost:9394/metrics")).split("\n").delete_if do |e|
+      e.blank? || e.start_with?("#")
+    end
+
+    metrics.each_with_object({}) do |m, hash|
+      k, v = m.split
+      hash[k] = v
+    end
+  end
+end

--- a/spec/collector_spec.rb
+++ b/spec/collector_spec.rb
@@ -1,4 +1,5 @@
 require "topological_inventory/amazon/collector"
+require "topological_inventory/amazon/collector/application_metrics"
 require 'aws-sdk'
 require 'aws-sdk-cloudformation'
 require 'aws-sdk-servicecatalog'
@@ -299,9 +300,11 @@ RSpec.describe TopologicalInventory::Amazon::Collector do
 
   def collect_and_parse(entity)
     parser = TopologicalInventory::Amazon::Parser.new
+    metrics = instance_double(TopologicalInventory::Amazon::Collector::ApplicationMetrics,
+                              :record_error => nil)
 
     collector = TopologicalInventory::Amazon::Collector.new(
-      "source", "access_key_id", "secret_access_key")
+      "source", "access_key_id", "secret_access_key", metrics)
     allow(collector).to receive(:save_inventory).and_return(1)
     allow(collector).to receive(:sweep_inventory)
     allow(collector).to receive(:create_parser).and_return(parser)


### PR DESCRIPTION
This adds an in-process metrics server using the prometheus exporter
gem and records an error metric each time an exception is caught
in the collector loop.