### PR TITLE
Metrics port as an argument

### DIFF
--- a/bin/amazon-collector
+++ b/bin/amazon-collector
@@ -13,13 +13,15 @@ def parse_args
   require 'optimist'
   opts = Optimist::options do
     opt :source, "Inventory Source UID",
-      :type => :string, :required => ENV["SOURCE_UID"].nil?, :default => ENV["SOURCE_UID"]
+        :type => :string, :required => ENV["SOURCE_UID"].nil?, :default => ENV["SOURCE_UID"]
     opt :access_key_id, "Secret access key for the Amazon API access",
-      :type => :string, :required => ENV["AUTH_USERNAME"].nil?, :default => ENV["AUTH_USERNAME"]
+        :type => :string, :required => ENV["AUTH_USERNAME"].nil?, :default => ENV["AUTH_USERNAME"]
     opt :secret_access_key, "Secret access key for the Amazon API access",
-      :type => :string, :required => ENV["AUTH_PASSWORD"].nil?, :default => ENV["AUTH_PASSWORD"]
+        :type => :string, :required => ENV["AUTH_PASSWORD"].nil?, :default => ENV["AUTH_PASSWORD"]
     opt :ingress_api, "Hostname of the ingress-api route",
-      :type => :string, :default => ENV["INGRESS_API"] || "http://localhost:9292"
+        :type => :string, :default => ENV["INGRESS_API"] || "http://localhost:9292"
+    opt :metrics_port, "Port to expose the metrics endpoint on, 0 to disable metrics",
+        :type => :integer, :default => (ENV["METRICS_PORT"] || 9394).to_i
   end
 
   opts
@@ -33,7 +35,7 @@ TopologicalInventoryIngressApiClient.configure.scheme = ingress_api_uri.scheme |
 TopologicalInventoryIngressApiClient.configure.host   = "#{ingress_api_uri.host}:#{ingress_api_uri.port}"
 
 begin
-  metrics = TopologicalInventory::Amazon::Collector::ApplicationMetrics.new
+  metrics = TopologicalInventory::Amazon::Collector::ApplicationMetrics.new(args[:metrics_port])
   collector = TopologicalInventory::Amazon::Collector.new(args[:source], args[:access_key_id], args[:secret_access_key], metrics)
   collector.collect!
 ensure

--- a/lib/topological_inventory/amazon/collector/application_metrics.rb
+++ b/lib/topological_inventory/amazon/collector/application_metrics.rb
@@ -8,16 +8,18 @@ module TopologicalInventory
     class Collector
       class ApplicationMetrics
         def initialize(port = 9394)
+          return if port == 0
+
           configure_server(port)
           configure_metrics
         end
 
         def record_error
-          @errors_counter.observe(1)
+          @errors_counter&.observe(1)
         end
 
         def stop_server
-          @server.stop
+          @server&.stop
         end
 
         private

--- a/spec/application_metrics_spec.rb
+++ b/spec/application_metrics_spec.rb
@@ -6,22 +6,33 @@ RSpec.describe TopologicalInventory::Amazon::Collector::ApplicationMetrics do
   subject! { described_class.new(9394) }
   after    { subject.stop_server }
 
-  it "exposes metrics" do
-    subject.record_error
-    subject.record_error
+  context "Turned on" do
+    it "exposes metrics" do
+      subject.record_error
+      subject.record_error
 
-    metrics = get_metrics
-    expect(metrics["topological_inventory_amazon_collector_errors_total"]).to eq("2")
-  end
-
-  def get_metrics
-    metrics = Net::HTTP.get(URI("http://localhost:9394/metrics")).split("\n").delete_if do |e|
-      e.blank? || e.start_with?("#")
+      metrics = get_metrics
+      expect(metrics["topological_inventory_amazon_collector_errors_total"]).to eq("2")
     end
 
-    metrics.each_with_object({}) do |m, hash|
-      k, v = m.split
-      hash[k] = v
+    def get_metrics
+      metrics = Net::HTTP.get(URI("http://localhost:9394/metrics")).split("\n").delete_if do |e|
+        e.blank? || e.start_with?("#")
+      end
+
+      metrics.each_with_object({}) do |m, hash|
+        k, v = m.split
+        hash[k] = v
+      end
+    end
+  end
+
+  context "Turned off" do
+    subject! { described_class.new(0) }
+
+    it "doesn't raise exception" do
+      expect { subject.record_error }.not_to raise_exception
+      expect { subject.stop_server }.not_to raise_exception
     end
   end
 end


### PR DESCRIPTION
Metrics port is configurable by metrics_port arg and `ENV["METRICS_PORT"]`. Defaults to 9394

Port 0 disables metrics