### PR TITLE
Adding the operations worker and processor for topological_inventory-amazon

### DIFF
--- a/bin/amazon-operations
+++ b/bin/amazon-operations
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+
+$LOAD_PATH << File.expand_path("../lib", __dir__)
+require "bundler/setup"
+require "topological_inventory/amazon/operations/worker"
+
+queue_host = ENV["QUEUE_HOST"] || "localhost"
+queue_port = ENV["QUEUE_PORT"] || 9092
+
+operations_worker = TopologicalInventory::Amazon::Operations::Worker.new(:host => queue_host, :port => queue_port)
+operations_worker.run

--- a/lib/topological_inventory/amazon/operations/processor.rb
+++ b/lib/topological_inventory/amazon/operations/processor.rb
@@ -1,0 +1,27 @@
+require "topological_inventory/amazon/logging"
+
+module TopologicalInventory
+  module Amazon
+    module Operations
+      class Processor
+        include Logging
+
+        def self.process!(message)
+          new(message).process
+        end
+
+        def initialize(message)
+          self.message = message
+        end
+
+        def process
+          # TODO: handle the operation
+        end
+
+        private
+
+        attr_accessor :message
+      end
+    end
+  end
+end

--- a/lib/topological_inventory/amazon/operations/worker.rb
+++ b/lib/topological_inventory/amazon/operations/worker.rb
@@ -1,0 +1,63 @@
+require "topological_inventory/amazon/logging"
+require "topological_inventory/amazon/operations/processor"
+
+module TopologicalInventory
+  module Amazon
+    module Operations
+      class Worker
+        include Logging
+
+        def initialize(messaging_client_opts = {})
+          self.messaging_client_opts = default_messaging_opts.merge(messaging_client_opts)
+        end
+
+        def run
+          # Open a connection to the messaging service
+          require "manageiq-messaging"
+          client = ManageIQ::Messaging::Client.open(messaging_client_opts)
+
+          logger.info("Topological Inventory Amazon Operations worker started...")
+          client.subscribe_topic(queue_opts) do |message|
+            process_message(message)
+          end
+        ensure
+          client&.close
+        end
+
+        private
+
+        attr_accessor :messaging_client_opts
+
+        def process_message(message)
+          Processor.process!(message)
+        rescue => e
+          logger.error("#{e}\n#{e.backtrace.join("\n")}")
+          raise
+        ensure
+          message.ack
+        end
+
+        def queue_name
+          "platform.topological-inventory.operations-amazon"
+        end
+
+        def queue_opts
+          {
+            :auto_ack    => false,
+            :max_bytes   => 50_000,
+            :service     => queue_name,
+            :persist_ref => "topological-inventory-operations-amazon"
+          }
+        end
+
+        def default_messaging_opts
+          {
+            :protocol   => :Kafka,
+            :client_ref => "topological-inventory-operations-amazon",
+            :group_ref  => "topological-inventory-operations-amazon"
+          }
+        end
+      end
+    end
+  end
+end

--- a/spec/operations/processor_spec.rb
+++ b/spec/operations/processor_spec.rb
@@ -1,0 +1,6 @@
+require "topological_inventory/amazon/operations/processor"
+
+RSpec.describe TopologicalInventory::Amazon::Operations::Processor do
+  describe "#process" do
+  end
+end

--- a/spec/operations/worker_spec.rb
+++ b/spec/operations/worker_spec.rb
@@ -1,0 +1,26 @@
+require "topological_inventory/amazon/operations/worker"
+
+RSpec.describe TopologicalInventory::Amazon::Operations::Worker do
+  describe "#run" do
+    let(:client) { double("ManageIQ::Messaging::Client") }
+    let(:subject) { described_class.new }
+    before do
+      require "manageiq-messaging"
+      allow(ManageIQ::Messaging::Client).to receive(:open).and_return(client)
+      allow(client).to receive(:close)
+    end
+
+    it "calls subscribe_topic on the right queue" do
+      operations_topic = "platform.topological-inventory.operations-amazon"
+
+      message = double("ManageIQ::Messaging::ReceivedMessage")
+      allow(message).to receive(:ack)
+
+      expect(client).to receive(:subscribe_topic)
+        .with(hash_including(:service => operations_topic)).and_yield(message)
+      expect(TopologicalInventory::Amazon::Operations::Processor)
+        .to receive(:process!).with(message)
+      subject.run
+    end
+  end
+end


### PR DESCRIPTION
Adding the operations worker and processor for amazon.

This is needed to support the availability check enhancement for the amazon source type.