### PR TITLE
Adding support for Source.availability_check

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,8 @@ gem 'manageiq-messaging'
 gem "more_core_extensions"
 gem "optimist"
 gem "prometheus_exporter", "~> 0.4.5"
-gem "rest-client", "~>2.0"
 gem "rake"
+gem "rest-client", "~>2.0"
 gem "sources-api-client",                       :git => "https://github.com/ManageIQ/sources-api-client-ruby", :branch => "master"
 gem "topological_inventory-ingress_api-client", :git => "https://github.com/ManageIQ/topological_inventory-ingress_api-client-ruby", :branch => "master"
 

--- a/Gemfile
+++ b/Gemfile
@@ -10,12 +10,15 @@ gem 'manageiq-messaging'
 gem "more_core_extensions"
 gem "optimist"
 gem "prometheus_exporter", "~> 0.4.5"
+gem "rest-client", "~>2.0"
 gem "rake"
+gem "sources-api-client",                       :git => "https://github.com/ManageIQ/sources-api-client-ruby", :branch => "master"
 gem "topological_inventory-ingress_api-client", :git => "https://github.com/ManageIQ/topological_inventory-ingress_api-client-ruby", :branch => "master"
 
 group :test, :devlopment do
   gem "rspec"
   gem "simplecov"
+  gem "webmock"
 end
 
 # Collector

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "rake"
 gem "sources-api-client",                       :git => "https://github.com/ManageIQ/sources-api-client-ruby", :branch => "master"
 gem "topological_inventory-ingress_api-client", :git => "https://github.com/ManageIQ/topological_inventory-ingress_api-client-ruby", :branch => "master"
 
-group :test, :devlopment do
+group :test, :development do
   gem "rspec"
   gem "simplecov"
   gem "webmock"

--- a/bin/amazon-operations
+++ b/bin/amazon-operations
@@ -7,5 +7,10 @@ require "topological_inventory/amazon/operations/worker"
 queue_host = ENV["QUEUE_HOST"] || "localhost"
 queue_port = ENV["QUEUE_PORT"] || 9092
 
+SourcesApiClient.configure do |config|
+  config.scheme = ENV["SOURCES_SCHEME"]
+  config.host   = "#{ENV["SOURCES_HOST"]}:#{ENV["SOURCES_PORT"]}"
+end
+
 operations_worker = TopologicalInventory::Amazon::Operations::Worker.new(:host => queue_host, :port => queue_port)
 operations_worker.run

--- a/lib/topological_inventory/amazon/operations/core/authentication_retriever.rb
+++ b/lib/topological_inventory/amazon/operations/core/authentication_retriever.rb
@@ -1,0 +1,44 @@
+require "sources-api-client"
+require "rest-client"
+
+module TopologicalInventory
+  module Amazon
+    module Operations
+      module Core
+        class AuthenticationRetriever
+          def initialize(id, identity = nil)
+            @id       = id.to_s
+            @identity = identity
+          end
+
+          def process
+            headers = {
+              "Content-Type" => "application/json"
+            }
+
+            headers.merge!(@identity) if @identity.present?
+
+            scheme     = SourcesApiClient.configure.scheme
+            host, port = SourcesApiClient.configure.host.split(":")
+
+            uri = URI::Generic.build(
+              :scheme => scheme,
+              :host   => host,
+              :port   => port,
+              :path   => "/internal/v1.0/authentications/#{@id}",
+              :query  => "expose_encrypted_attribute[]=password"
+            )
+
+            request_options = {
+              :method  => :get,
+              :url     => uri.to_s,
+              :headers => headers
+            }
+            response = RestClient::Request.new(request_options).execute
+            SourcesApiClient::Authentication.new(JSON.parse(response.body))
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/topological_inventory/amazon/operations/processor.rb
+++ b/lib/topological_inventory/amazon/operations/processor.rb
@@ -12,15 +12,29 @@ module TopologicalInventory
 
         def initialize(message)
           self.message = message
+          self.model, self.method = message.message.split(".")
+
+          self.params   = message.payload["params"]
+          self.identity = message.payload["request_context"]
         end
 
         def process
-          # TODO: handle the operation
+          logger.info("Processing #{model}##{method} [#{params}]...")
+
+          impl = Operations.const_get(model).new(params, identity) if Operations.const_defined?(model)
+          unless impl
+            logger.error("#{model}.#{method} is not implemented")
+            return
+          end
+
+          result = impl.send(method)
+          logger.info("Processing #{model}##{method} [#{params}]...Complete")
+          result
         end
 
         private
 
-        attr_accessor :message
+        attr_accessor :message, :identity, :model, :method, :params
       end
     end
   end

--- a/lib/topological_inventory/amazon/operations/source.rb
+++ b/lib/topological_inventory/amazon/operations/source.rb
@@ -1,4 +1,5 @@
 require "sources-api-client"
+require "active_support/core_ext/numeric/time"
 require "topological_inventory/amazon/connection"
 require "topological_inventory/amazon/operations/core/authentication_retriever"
 

--- a/lib/topological_inventory/amazon/operations/source.rb
+++ b/lib/topological_inventory/amazon/operations/source.rb
@@ -25,11 +25,6 @@ module TopologicalInventory
             return
           end
 
-          # Let's skip the request if it's older than a minute ago.
-          if params["timestamp"]
-            return if params["timestamp"] < (Time.now.utc - 1.minute)
-          end
-
           source = SourcesApiClient::Source.new
           source.availability_status = connection_check(source_id)
 

--- a/lib/topological_inventory/amazon/operations/source.rb
+++ b/lib/topological_inventory/amazon/operations/source.rb
@@ -1,0 +1,88 @@
+require "sources-api-client"
+require "topological_inventory/amazon/connection"
+require "topological_inventory/amazon/operations/core/authentication_retriever"
+
+module TopologicalInventory
+  module Amazon
+    module Operations
+      class Source
+        include Logging
+        STATUS_AVAILABLE, STATUS_UNAVAILABLE = %w[available unavailable].freeze
+
+        attr_accessor :params, :context, :source_id
+
+        def initialize(params = {}, request_context = nil)
+          @params  = params
+          @context = request_context
+          @source_id = nil
+        end
+
+        def availability_check
+          source_id = params["source_id"]
+          unless source_id
+            logger.error("Missing source_id for the availability_check request")
+            return
+          end
+
+          # Let's skip the request if it's older than a minute ago.
+          if params["timestamp"]
+            return if params["timestamp"] < (Time.now.utc - 1.minute)
+          end
+
+          source = SourcesApiClient::Source.new
+          source.availability_status = connection_check(source_id)
+
+          begin
+            api_client.update_source(source_id, source)
+          rescue SourcesApiClient::ApiError => e
+            logger.error("Failed to update Source id:#{source_id} - #{e.message}")
+          end
+        end
+
+        private
+
+        def connection_check(source_id)
+          endpoints = api_client.list_source_endpoints(source_id)&.data || []
+          endpoint = endpoints.find(&:default)
+          return STATUS_UNAVAILABLE unless endpoint
+
+          endpoint_authentications = api_client.list_endpoint_authentications(endpoint.id.to_s).data || []
+          return STATUS_UNAVAILABLE if endpoint_authentications.empty?
+
+          auth_id = endpoint_authentications.first.id
+          auth = Core::AuthenticationRetriever.new(auth_id, identity).process
+          return STATUS_UNAVAILABLE unless auth
+
+          ec2_connection = TopologicalInventory::Amazon::Connection.ec2(
+            :access_key_id     => auth.username,
+            :secret_access_key => auth.password,
+            :region            => region
+          )
+
+          ec2_connection.client.describe_regions.regions
+
+          STATUS_AVAILABLE
+        rescue => e
+          logger.error("Failed to connect to Source id:#{source_id} - #{e.message}")
+          STATUS_UNAVAILABLE
+        end
+
+        def identity
+          @identity ||= { "x-rh-identity" => Base64.encode64({ "identity" => { "account_number" => params["external_tenant"] }}.to_json) }
+        end
+
+        def api_client
+          @api_client ||= begin
+            api_client = SourcesApiClient::ApiClient.new
+            api_client.default_headers.merge!(identity)
+            SourcesApiClient::DefaultApi.new(api_client)
+          end
+        end
+
+        def region
+          ENV["REGION"] || "us-east-1"
+        end
+      end
+    end
+  end
+end

--- a/lib/topological_inventory/amazon/operations/source.rb
+++ b/lib/topological_inventory/amazon/operations/source.rb
@@ -81,7 +81,7 @@ module TopologicalInventory
         end
 
         def region
-          ENV["REGION"] || "us-east-1"
+          "us-east-1"
         end
       end
     end

--- a/lib/topological_inventory/amazon/operations/worker.rb
+++ b/lib/topological_inventory/amazon/operations/worker.rb
@@ -1,5 +1,6 @@
 require "topological_inventory/amazon/logging"
 require "topological_inventory/amazon/operations/processor"
+require "topological_inventory/amazon/operations/source"
 
 module TopologicalInventory
   module Amazon

--- a/spec/application_metrics_spec.rb
+++ b/spec/application_metrics_spec.rb
@@ -5,6 +5,11 @@ require "net/http"
 RSpec.describe TopologicalInventory::Amazon::Collector::ApplicationMetrics do
   subject! { described_class.new(9394) }
   after    { subject.stop_server }
+  around do |example|
+    WebMock.disable!
+    example.run
+    WebMock.enable!
+  end
 
   context "Turned on" do
     it "exposes metrics" do

--- a/spec/operations/source_spec.rb
+++ b/spec/operations/source_spec.rb
@@ -1,0 +1,34 @@
+require "sources-api-client"
+require "topological_inventory/amazon/operations/source"
+
+RSpec.describe(TopologicalInventory::Amazon::Operations::Source) do
+  describe "availability_check" do
+    let(:host_url) { "https://cloud.redhat.com" }
+    let(:external_tenant) { "11001" }
+    let(:identity) do
+      { "x-rh-identity" => Base64.encode64({ "identity" => { "account_number" => external_tenant } }.to_json) }
+    end
+    let(:headers) { {"Content-Type" => "application/json"}.merge(identity) }
+
+    it "makes a patch request to update the availability_status of a source" do
+      source_id = "201"
+      payload =
+        {
+          "params" => {
+            "source_id"       => source_id,
+            "external_tenant" => external_tenant,
+            "timestamp"       => Time.now.utc
+          }
+        }
+
+      stub_request(:get, "https://cloud.redhat.com/api/sources/v1.0/sources/#{source_id}/endpoints")
+        .with(:headers => headers)
+        .to_return(:status => 200, :body => "", :headers => {})
+      stub_request(:patch, "https://cloud.redhat.com/api/sources/v1.0/sources/#{source_id}")
+        .with(:body => {"availability_status" => "unavailable"}.to_json, :headers => headers)
+        .to_return(:status => 200, :body => "", :headers => {})
+
+      described_class.new(payload["params"]).availability_check
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,8 @@ if ENV['CI']
   SimpleCov.start
 end
 
+require "rspec"
+require "webmock/rspec"
 require "topological_inventory/amazon/collector"
 
 RSpec.configure do |config|


### PR DESCRIPTION
- Adding hook in Processor to invoke the model.method to handling the inbound messages.
- Adding the Source.availability_check logic to do an EC2 connection check
- Adding spec test or the Source.availability_check

Depends on:
 - [x] https://github.com/ManageIQ/sources-api-client-ruby/pull/5
