### PR TITLE
Should be using strict_encode64 for building the identity header.

### DIFF
--- a/lib/topological_inventory/amazon/operations/source.rb
+++ b/lib/topological_inventory/amazon/operations/source.rb
@@ -64,7 +64,7 @@ module TopologicalInventory
         end
 
         def identity
-          @identity ||= { "x-rh-identity" => Base64.encode64({ "identity" => { "account_number" => params["external_tenant"] }}.to_json) }
+          @identity ||= { "x-rh-identity" => Base64.strict_encode64({ "identity" => { "account_number" => params["external_tenant"] }}.to_json) }
         end
 
         def api_client

--- a/spec/operations/source_spec.rb
+++ b/spec/operations/source_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe(TopologicalInventory::Amazon::Operations::Source) do
     let(:host_url) { "https://cloud.redhat.com" }
     let(:external_tenant) { "11001" }
     let(:identity) do
-      { "x-rh-identity" => Base64.encode64({ "identity" => { "account_number" => external_tenant } }.to_json) }
+      { "x-rh-identity" => Base64.strict_encode64({ "identity" => { "account_number" => external_tenant } }.to_json) }
     end
     let(:headers) { {"Content-Type" => "application/json"}.merge(identity) }
 


### PR DESCRIPTION

Should be using strict_encode64 for building the identity header.

- without this, was getting header field value cannot include CR/LF errors with the RestClient with some external tenant names.