### PR TITLE
Moving collector's common from ingress-api-client-ruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundle
 
 gem "activesupport", "~> 5.2.2"
 gem "concurrent-ruby"
-gem "manageiq-loggers", "~> 0.1.1"
+gem "manageiq-loggers", "~> 0.3.0"
 gem 'manageiq-messaging'
 gem "more_core_extensions"
 gem "optimist"
@@ -14,7 +14,7 @@ gem "rake"
 gem "rest-client", "~>2.0"
 gem "sources-api-client",                       :git => "https://github.com/ManageIQ/sources-api-client-ruby", :branch => "master"
 gem "topological_inventory-ingress_api-client", :git => "https://github.com/ManageIQ/topological_inventory-ingress_api-client-ruby", :branch => "master"
-
+gem "topological_inventory-providers-common",   :git => "https://github.com/ManageIQ/topological_inventory-providers-common", :branch => "master"
 group :test, :development do
   gem "rspec"
   gem "simplecov"

--- a/lib/topological_inventory/amazon/collector.rb
+++ b/lib/topological_inventory/amazon/collector.rb
@@ -1,14 +1,13 @@
 require "concurrent"
-require "topological_inventory-ingress_api-client/collector"
+require "topological_inventory/providers/common/collector"
 require "topological_inventory/amazon/connection"
 require "topological_inventory/amazon/parser"
 require "topological_inventory/amazon/iterator"
 require "topological_inventory/amazon/logging"
-require "topological_inventory-ingress_api-client"
 
 module TopologicalInventory
   module Amazon
-    class Collector < ::TopologicalInventoryIngressApiClient::Collector
+    class Collector < ::TopologicalInventory::Providers::Common::Collector
       include Logging
 
       require "topological_inventory/amazon/collector/cloud_formation"

--- a/lib/topological_inventory/amazon/collectors_pool.rb
+++ b/lib/topological_inventory/amazon/collectors_pool.rb
@@ -1,9 +1,9 @@
-require "topological_inventory-ingress_api-client/collectors_pool"
+require "topological_inventory/providers/common/collectors_pool"
 require "topological_inventory/amazon/collector"
 require "topological_inventory/amazon/logging"
 
 module TopologicalInventory::Amazon
-  class CollectorsPool < TopologicalInventoryIngressApiClient::CollectorsPool
+  class CollectorsPool < TopologicalInventory::Providers::Common::CollectorsPool
     include Logging
 
     def initialize(config_name, metrics, poll_time: 10)

--- a/lib/topological_inventory/amazon/parser.rb
+++ b/lib/topological_inventory/amazon/parser.rb
@@ -1,26 +1,24 @@
-require "active_support/inflector"
-require "topological_inventory/amazon/parser/source_region"
-require "topological_inventory/amazon/parser/service_offering"
-require "topological_inventory/amazon/parser/service_plan"
-require "topological_inventory/amazon/parser/service_instance"
-require "topological_inventory/amazon/parser/subscription"
-require "topological_inventory/amazon/parser/flavor"
-require "topological_inventory/amazon/parser/floating_ip"
-require "topological_inventory/amazon/parser/network"
-require "topological_inventory/amazon/parser/network_adapter"
-require "topological_inventory/amazon/parser/reservation"
-require "topological_inventory/amazon/parser/security_group"
-require "topological_inventory/amazon/parser/subnet"
-require "topological_inventory/amazon/parser/vm"
-require "topological_inventory/amazon/parser/volume"
-require "topological_inventory/amazon/parser/volume_type"
-require "topological_inventory-ingress_api-client"
-require "topological_inventory-ingress_api-client/collector.rb"
-require "topological_inventory-ingress_api-client/collector/inventory_collection_storage.rb"
+require "topological_inventory/providers/common/collector/parser"
 
 module TopologicalInventory
   module Amazon
-    class Parser
+    class Parser < TopologicalInventory::Providers::Common::Collector::Parser
+      require "topological_inventory/amazon/parser/source_region"
+      require "topological_inventory/amazon/parser/service_offering"
+      require "topological_inventory/amazon/parser/service_plan"
+      require "topological_inventory/amazon/parser/service_instance"
+      require "topological_inventory/amazon/parser/flavor"
+      require "topological_inventory/amazon/parser/floating_ip"
+      require "topological_inventory/amazon/parser/network"
+      require "topological_inventory/amazon/parser/network_adapter"
+      require "topological_inventory/amazon/parser/reservation"
+      require "topological_inventory/amazon/parser/security_group"
+      require "topological_inventory/amazon/parser/subnet"
+      require "topological_inventory/amazon/parser/subscription"
+      require "topological_inventory/amazon/parser/vm"
+      require "topological_inventory/amazon/parser/volume"
+      require "topological_inventory/amazon/parser/volume_type"
+
       include Parser::SourceRegion
       include Parser::ServiceOffering
       include Parser::ServicePlan
@@ -37,12 +35,11 @@ module TopologicalInventory
       include Parser::Volume
       include Parser::VolumeType
 
-      attr_accessor :connection, :collections, :resource_timestamp
+      attr_accessor :connection
 
       def initialize(connection = nil)
+        super()
         self.connection         = connection
-        self.resource_timestamp = Time.now.utc
-        self.collections = TopologicalInventoryIngressApiClient::Collector::InventoryCollectionStorage.new
       end
 
       private
@@ -71,14 +68,6 @@ module TopologicalInventory
       def archive_entity(inventory_object, entity)
         source_deleted_at                  = entity.metadata&.deletionTimestamp || Time.now.utc
         inventory_object.source_deleted_at = source_deleted_at
-      end
-
-      def lazy_find(collection, reference, ref: :manager_ref)
-        TopologicalInventoryIngressApiClient::InventoryObjectLazy.new(
-          :inventory_collection_name => collection,
-          :reference                 => reference,
-          :ref                       => ref,
-        )
       end
 
       def lazy_find_subscription(scope)


### PR DESCRIPTION
to providers-common gem, because ingress-api-client is built from generator

---

- [x] **depends on** https://github.com/ManageIQ/topological_inventory-providers-common/pull/1