### PR TITLE
Refresh master account subaccounts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem "aws-sdk-ec2", "~>1.102.0"
 gem "aws-sdk-cloudformation", "~>1.25.0"
 gem "aws-sdk-pricing", "~>1.15.0"
 gem "aws-sdk-servicecatalog", "~>1.32.0"
+gem "aws-sdk-organizations", "~>1.32.0"
 
 # Event catcher
 gem "aws-sdk-sqs", "~>1.20.0"

--- a/bin/amazon-collector
+++ b/bin/amazon-collector
@@ -21,6 +21,8 @@ def parse_args
         :type => :string, :default => ENV["AUTH_USERNAME"]
     opt :secret_access_key, "Secret access key for the Amazon API access",
         :type => :string, :default => ENV["AUTH_PASSWORD"]
+    opt :sub_account_role, "Role name that will be used to access all usb-accounts in the organization",
+        :type => :string, :default => ENV["SUB_ACCOUNT_ROLE"]
     opt :ingress_api, "Hostname of the ingress-api route",
         :type => :string, :default => ENV["INGRESS_API"] || "http://localhost:9292"
     opt :metrics_port, "Port to expose the metrics endpoint on, 0 to disable metrics",

--- a/bin/amazon-collector
+++ b/bin/amazon-collector
@@ -21,7 +21,7 @@ def parse_args
         :type => :string, :default => ENV["AUTH_USERNAME"]
     opt :secret_access_key, "Secret access key for the Amazon API access",
         :type => :string, :default => ENV["AUTH_PASSWORD"]
-    opt :sub_account_role, "Role name that will be used to access all usb-accounts in the organization",
+    opt :sub_account_role, "Role name that will be used to access all sub-accounts in the organization",
         :type => :string, :default => ENV["SUB_ACCOUNT_ROLE"]
     opt :ingress_api, "Hostname of the ingress-api route",
         :type => :string, :default => ENV["INGRESS_API"] || "http://localhost:9292"

--- a/bin/amazon-collector
+++ b/bin/amazon-collector
@@ -56,7 +56,8 @@ TopologicalInventoryIngressApiClient.configure.host   = "#{ingress_api_uri.host}
 begin
   metrics = TopologicalInventory::Amazon::Collector::ApplicationMetrics.new(args[:metrics_port])
   if args[:config].nil?
-    collector = TopologicalInventory::Amazon::Collector.new(args[:source], args[:access_key_id], args[:secret_access_key], metrics)
+    collector = TopologicalInventory::Amazon::Collector.new(
+      args[:source], args[:access_key_id], args[:secret_access_key], args[:sub_account_role], metrics)
     collector.collect!
   else
     pool = TopologicalInventory::Amazon::CollectorsPool.new(args[:config], metrics)

--- a/lib/topological_inventory/amazon/collector.rb
+++ b/lib/topological_inventory/amazon/collector.rb
@@ -36,7 +36,7 @@ module TopologicalInventory
           begin
             regions          = ec2_connection(:region => default_region).client.describe_regions.regions.map(&:region_name)
             accounts         = list_accounts
-            sub_account_role = "OrganizationAccountAccessRole"
+            sub_account_role = "ReadOnlyRole"
 
             # Scan accounts first, to see which are accessible and use only those
             accounts.delete_if {|account| !valid_account?(default_region, account, sub_account_role)}

--- a/lib/topological_inventory/amazon/collector/cloud_formation.rb
+++ b/lib/topological_inventory/amazon/collector/cloud_formation.rb
@@ -11,14 +11,14 @@ module TopologicalInventory
         def orchestration_stack_resources(stack_name, scope)
           cloud_formation_connection(scope).client.list_stack_resources(:stack_name => stack_name).try(:stack_resource_summaries) || []
         rescue => e
-          log.warn("Couldn't fetch 'list_stack_resources' from CloudFormation, message: #{e.message}")
+          logger.warn("Couldn't fetch 'list_stack_resources' from CloudFormation, message: #{e.message}")
           nil
         end
 
         def orchestration_stack_template(stack_name, scope)
           cloud_formation_connection(scope).client.get_template(:stack_name => stack_name).template_body
         rescue => e
-          log.warn("Couldn't fetch 'get_template' from CloudFormation, message: #{e.message}")
+          logger.warn("Couldn't fetch 'get_template' from CloudFormation, message: #{e.message}")
           nil
         end
       end

--- a/lib/topological_inventory/amazon/collector/cloud_formation.rb
+++ b/lib/topological_inventory/amazon/collector/cloud_formation.rb
@@ -11,14 +11,14 @@ module TopologicalInventory
         def orchestration_stack_resources(stack_name, scope)
           cloud_formation_connection(scope).client.list_stack_resources(:stack_name => stack_name).try(:stack_resource_summaries) || []
         rescue => e
-          logger.warn("Couldn't fetch 'list_stack_resources' from CloudFormation, message: #{e.message}")
+          logger.warn("Couldn't fetch 'list_stack_resources' from CloudFormation with scope #{scope}, message: #{e.message}")
           nil
         end
 
         def orchestration_stack_template(stack_name, scope)
           cloud_formation_connection(scope).client.get_template(:stack_name => stack_name).template_body
         rescue => e
-          logger.warn("Couldn't fetch 'get_template' from CloudFormation, message: #{e.message}")
+          logger.warn("Couldn't fetch 'get_template' from CloudFormation with scope #{scope}, message: #{e.message}")
           nil
         end
       end

--- a/lib/topological_inventory/amazon/collector/ec2.rb
+++ b/lib/topological_inventory/amazon/collector/ec2.rb
@@ -4,7 +4,7 @@ module TopologicalInventory
       module Ec2
         def source_regions(scope)
           # We want to collect this for only default region, since all regions return the same result
-          return [] unless scope[:region] == default_region
+          return [] unless scope[:region] == default_region && scope[:master]
 
           paginated_query(scope, :ec2_connection, :regions)
         end

--- a/lib/topological_inventory/amazon/collector/organizations.rb
+++ b/lib/topological_inventory/amazon/collector/organizations.rb
@@ -1,0 +1,54 @@
+module TopologicalInventory
+  module Amazon
+    class Collector
+      module Organizations
+        def subscriptions(scope)
+          # Get cached result
+          return @subscriptions_cache if @subscriptions_cache
+
+          # We want to collect this for only default region, since all regions return the same result
+          return [] unless scope[:region] == default_region && scope[:master]
+
+          # Get all accounts inside AWS organization
+          @subscriptions_cache = []
+
+          # If we were able to load master account and we have role defined for sub account access, we can load
+          # a list of subaccounts
+          if sub_account_role
+            begin
+              master_account_id = organizations_connection(:region => default_region).client.describe_organization&.organization&.master_account_id
+            rescue Aws::Organizations::Errors::AccessDeniedException => e
+              logger.warn("Can't access describe_organization API, [#{e.class}, #{e.message}]")
+            end
+            if master_account_id
+              begin
+                paginated_query({:region => default_region}, :organizations_connection,
+                                :accounts, :listing_keyword => "list").each do |account|
+                  @subscriptions_cache << {
+                    :account_id   => account.id,
+                    :master       => account.id == master_account_id,
+                    :account_name => account.name
+                  }
+                end
+              rescue Aws::Organizations::Errors::AccessDeniedException => e
+                logger.warn("Can't access list_organizations API, [#{e.class}, #{e.message}]")
+              end
+            end
+          end
+
+          # If we are not able to scan organization just add current creds as a master account
+          if @subscriptions_cache.empty?
+            # TODO(lsmola): try to fetch account number from other API
+            @subscriptions_cache << {
+              :account_id   => nil,
+              :master       => true,
+              :account_name => nil
+            }
+          end
+
+          @subscriptions_cache
+        end
+      end
+    end
+  end
+end

--- a/lib/topological_inventory/amazon/collector/pricing.rb
+++ b/lib/topological_inventory/amazon/collector/pricing.rb
@@ -36,7 +36,7 @@ module TopologicalInventory
               result = flavors_query(scope, :next_token => result.next_token)
             end
           end
-          Iterator.new(func, "Couldn't fetch 'flavors' from Aws::Pricing.")
+          Iterator.new(func, "Couldn't fetch 'flavors' from Aws::Pricing with scope #{scope}.")
         end
 
         def volume_types(scope)
@@ -57,7 +57,7 @@ module TopologicalInventory
               result = volume_types_query(scope, :next_token => result.next_token)
             end
           end
-          Iterator.new(func, "Couldn't fetch 'volume_types' from Aws::Pricing.")
+          Iterator.new(func, "Couldn't fetch 'volume_types' from Aws::Pricing with scope #{scope}.")
         end
 
         private

--- a/lib/topological_inventory/amazon/collector/pricing.rb
+++ b/lib/topological_inventory/amazon/collector/pricing.rb
@@ -21,7 +21,7 @@ module TopologicalInventory
         def flavors(scope)
           # TODO(lsmola) should we have flavor per region? Are there region specific flavors?
           # We want to collect this for only default region, since all regions return the same result
-          return [] unless scope[:region] == default_region
+          return [] unless scope[:region] == default_region && scope[:master]
 
           func = lambda do |&blk|
             result = flavors_query(scope)
@@ -42,7 +42,7 @@ module TopologicalInventory
         def volume_types(scope)
           # TODO(lsmola) should we have volume_type per region? Are there region specific volume types?
           # We want to collect this for only default region, since all regions return the same result
-          return [] unless scope[:region] == default_region
+          return [] unless scope[:region] == default_region && scope[:master]
 
           func = lambda do |&blk|
             result = volume_types_query(scope)

--- a/lib/topological_inventory/amazon/collector/service_catalog.rb
+++ b/lib/topological_inventory/amazon/collector/service_catalog.rb
@@ -5,7 +5,7 @@ module TopologicalInventory
         def service_offerings(scope)
           service_catalog_connection(scope).client.search_products_as_admin.product_view_details
         rescue => e
-          log.error("Couldn't fetch 'search_products_as_admin' of service catalog, message: #{e.message}")
+          logger.error("Couldn't fetch 'search_products_as_admin' of service catalog, message: #{e.message}")
           []
         end
 
@@ -57,28 +57,28 @@ module TopologicalInventory
           )
         rescue => e
           ident = {:product_id => product_id, :artifact_id => artifact_id, :launch_path_id => launch_path_id}
-          log.warn("Couldn't fetch 'describe_provisioning_parameters' of service catalog for #{ident}, message: #{e.message}")
+          logger.warn("Couldn't fetch 'describe_provisioning_parameters' of service catalog for #{ident}, message: #{e.message}")
           nil
         end
 
         def describe_product(product_id, scope)
           service_catalog_connection(scope).client.describe_product(:id => product_id).provisioning_artifacts
         rescue => e
-          log.warn("Couldn't fetch 'describe_product' of service catalog, message: #{e.message}")
+          logger.warn("Couldn't fetch 'describe_product' of service catalog, message: #{e.message}")
           []
         end
 
         def list_launch_paths(product_id, scope)
           service_catalog_connection(scope).client.list_launch_paths(:product_id => product_id).launch_path_summaries
         rescue => e
-          log.warn("Couldn't fetch 'list_launch_paths' of service catalog, message: #{e.message}")
+          logger.warn("Couldn't fetch 'list_launch_paths' of service catalog, message: #{e.message}")
           []
         end
 
         def describe_record(record_id, scope)
           service_catalog_connection(scope).client.describe_record(:id => record_id)
         rescue => e
-          log.warn("Couldn't fetch 'describe_record' of service catalog, message: #{e.message}")
+          logger.warn("Couldn't fetch 'describe_record' of service catalog, message: #{e.message}")
           nil
         end
       end

--- a/lib/topological_inventory/amazon/collector/service_catalog.rb
+++ b/lib/topological_inventory/amazon/collector/service_catalog.rb
@@ -5,7 +5,7 @@ module TopologicalInventory
         def service_offerings(scope)
           service_catalog_connection(scope).client.search_products_as_admin.product_view_details
         rescue => e
-          logger.error("Couldn't fetch 'search_products_as_admin' of service catalog, message: #{e.message}")
+          logger.error("Couldn't fetch 'search_products_as_admin' of service catalog with #{scope}, message: #{e.message}")
           []
         end
 
@@ -15,7 +15,7 @@ module TopologicalInventory
               blk.call(:service_instance => service_instance, :described_record => describe_record(service_instance.last_record_id, scope))
             end
           end
-          Iterator.new(func, "Couldn't fetch 'provisioned_products' of service catalog.")
+          Iterator.new(func, "Couldn't fetch 'provisioned_products' of service catalog with scope #{scope}.")
         end
 
         def service_plans(scope)
@@ -44,7 +44,7 @@ module TopologicalInventory
             end
           end
 
-          Iterator.new(func, "Couldn't fetch 'describe_provisioning_parameters' of service catalog.")
+          Iterator.new(func, "Couldn't fetch 'describe_provisioning_parameters' of service catalog with scope #{scope}.")
         end
 
         private
@@ -57,28 +57,28 @@ module TopologicalInventory
           )
         rescue => e
           ident = {:product_id => product_id, :artifact_id => artifact_id, :launch_path_id => launch_path_id}
-          logger.warn("Couldn't fetch 'describe_provisioning_parameters' of service catalog for #{ident}, message: #{e.message}")
+          logger.warn("Couldn't fetch 'describe_provisioning_parameters' of service catalog for #{ident} with scope #{scope}, message: #{e.message}")
           nil
         end
 
         def describe_product(product_id, scope)
           service_catalog_connection(scope).client.describe_product(:id => product_id).provisioning_artifacts
         rescue => e
-          logger.warn("Couldn't fetch 'describe_product' of service catalog, message: #{e.message}")
+          logger.warn("Couldn't fetch 'describe_product' of service catalog with scope #{scope}, message: #{e.message}")
           []
         end
 
         def list_launch_paths(product_id, scope)
           service_catalog_connection(scope).client.list_launch_paths(:product_id => product_id).launch_path_summaries
         rescue => e
-          logger.warn("Couldn't fetch 'list_launch_paths' of service catalog, message: #{e.message}")
+          logger.warn("Couldn't fetch 'list_launch_paths' of service catalog with scope #{scope}, message: #{e.message}")
           []
         end
 
         def describe_record(record_id, scope)
           service_catalog_connection(scope).client.describe_record(:id => record_id)
         rescue => e
-          logger.warn("Couldn't fetch 'describe_record' of service catalog, message: #{e.message}")
+          logger.warn("Couldn't fetch 'describe_record' of service catalog with scope #{scope}, message: #{e.message}")
           nil
         end
       end

--- a/lib/topological_inventory/amazon/connection.rb
+++ b/lib/topological_inventory/amazon/connection.rb
@@ -34,29 +34,36 @@ module TopologicalInventory
           open(options.merge(:service => :SNS))
         end
 
-        def open(options = {})
-          access_key_id     = options[:access_key_id]
-          secret_access_key = options[:secret_access_key]
-          service           = options[:service]
-          proxy             = options[:proxy_uri]
-          region            = options[:region]
+        def organizations(options)
+          open(options.merge(:service => :Organizations))
+        end
 
-          raw_connect(access_key_id, secret_access_key, service, region, proxy)
+        def open(options = {})
+          access_key_id        = options[:access_key_id]
+          secret_access_key    = options[:secret_access_key]
+          service              = options[:service]
+          region               = options[:region]
+          proxy_uri            = options[:proxy_uri]
+          sub_account_role_arn = options[:sub_account_role_arn]
+
+          raw_connect(access_key_id, secret_access_key, service, region, :proxy_uri => proxy_uri,
+                      :sub_account_role_arn => sub_account_role_arn)
         end
 
         private
 
-        def raw_connect(access_key_id, secret_access_key, service, region, proxy_uri = nil, validate = false, uri = nil)
+        def raw_connect(access_key_id, secret_access_key, service, region, proxy_uri: nil,
+                        validate: false, uri: nil, sub_account_role_arn: nil)
           require "aws-sdk-ec2"
           require "aws-sdk-cloudformation"
           require "aws-sdk-pricing"
           require "aws-sdk-servicecatalog"
+          require "aws-sdk-organizations"
 
           options = {
-            :access_key_id     => access_key_id,
-            :secret_access_key => secret_access_key,
-            :region            => region,
-            :http_proxy        => proxy_uri,
+            :credentials => Aws::Credentials.new(access_key_id, secret_access_key),
+            :region      => region,
+            :http_proxy  => proxy_uri,
             # :logger            => $aws_log,
             # :log_level         => :debug,
             # :log_formatter     => Aws::Log::Formatter.new(Aws::Log::Formatter.default.pattern.chomp)
@@ -64,42 +71,15 @@ module TopologicalInventory
 
           options[:endpoint] = uri.to_s unless uri.nil?
 
-          connection = Aws.const_get(service)::Resource.new(options)
-
-          validate_connection(connection) if validate
-
-          connection
-        end
-
-        def validate_connection(connection)
-          connection_rescue_block do
-            connection.client.describe_regions.regions.map(&:region_name)
+          if sub_account_role_arn
+            options[:credentials] = Aws::AssumeRoleCredentials.new(
+              :client            => Aws::STS::Client.new(options),
+              :role_arn          => sub_account_role_arn,
+              :role_session_name => "TopologicalInventory-#{service}"
+            )
           end
-        end
 
-        def connection_rescue_block
-          yield
-        rescue => err
-          miq_exception = translate_exception(err)
-          raise unless miq_exception
-
-          log.error("Error Class=#{err.class.name}, Message=#{err.message}")
-          raise miq_exception
-        end
-
-        def translate_exception(err)
-          # require 'aws-sdk'
-          # # require 'patches/aws-sdk-core/seahorse_client_net_http_pool_patch'
-          # case err
-          # when Aws::EC2::Errors::SignatureDoesNotMatch
-          #   MiqException::MiqHostError.new "SignatureMismatch - check your AWS Secret Access Key and signing method"
-          # when Aws::EC2::Errors::AuthFailure
-          #   MiqException::MiqHostError.new "Login failed due to a bad username or password."
-          # when Aws::Errors::MissingCredentialsError
-          #   MiqException::MiqHostError.new "Missing credentials"
-          # else
-          #   MiqException::MiqHostError.new "Unexpected response returned from system: #{err.message}"
-          # end
+          Aws.const_get(service)::Resource.new(options)
         end
       end
     end

--- a/lib/topological_inventory/amazon/iterator.rb
+++ b/lib/topological_inventory/amazon/iterator.rb
@@ -1,5 +1,7 @@
 module TopologicalInventory::Amazon
   class Iterator
+    include Logging
+
     attr_reader :block, :error_message, :log
 
     def initialize(blk, error_message)
@@ -13,7 +15,7 @@ module TopologicalInventory::Amazon
         yield(entity)
       end
     rescue => e
-      log.warn("#{error_message}. Message: #{e.message}")
+      logger.warn("#{error_message}. Message: #{e.message}")
       []
     end
   end

--- a/lib/topological_inventory/amazon/iterator.rb
+++ b/lib/topological_inventory/amazon/iterator.rb
@@ -1,3 +1,5 @@
+require "topological_inventory/amazon/logging"
+
 module TopologicalInventory::Amazon
   class Iterator
     include Logging

--- a/lib/topological_inventory/amazon/parser.rb
+++ b/lib/topological_inventory/amazon/parser.rb
@@ -3,6 +3,7 @@ require "topological_inventory/amazon/parser/source_region"
 require "topological_inventory/amazon/parser/service_offering"
 require "topological_inventory/amazon/parser/service_plan"
 require "topological_inventory/amazon/parser/service_instance"
+require "topological_inventory/amazon/parser/subscription"
 require "topological_inventory/amazon/parser/flavor"
 require "topological_inventory/amazon/parser/floating_ip"
 require "topological_inventory/amazon/parser/network"
@@ -23,6 +24,7 @@ module TopologicalInventory
       include Parser::ServiceOffering
       include Parser::ServicePlan
       include Parser::ServiceInstance
+      include Parser::Subscription
       include Parser::Flavor
       include Parser::FloatingIp
       include Parser::Network

--- a/lib/topological_inventory/amazon/parser.rb
+++ b/lib/topological_inventory/amazon/parser.rb
@@ -77,6 +77,12 @@ module TopologicalInventory
         )
       end
 
+      def lazy_find_subscription(scope)
+        if scope[:account_id]
+          lazy_find(:subscriptions, :source_ref => scope[:account_id])
+        end
+      end
+
       def get_from_tags(tags, tag_name)
         (tags || []).detect { |tag| tag.key.downcase == tag_name.to_s.downcase }&.value
       end

--- a/lib/topological_inventory/amazon/parser/floating_ip.rb
+++ b/lib/topological_inventory/amazon/parser/floating_ip.rb
@@ -20,6 +20,7 @@ module TopologicalInventory::Amazon
             :private_ip_address => ip.private_ip_address,
           },
           :source_region       => lazy_find(:source_regions, :source_ref => scope[:region]),
+          :subscription        => lazy_find_subscription(scope),
           :orchestration_stack => stack,
           :network_adapter     => network_adapter,
         )

--- a/lib/topological_inventory/amazon/parser/network.rb
+++ b/lib/topological_inventory/amazon/parser/network.rb
@@ -19,6 +19,7 @@ module TopologicalInventory::Amazon
 
           },
           :source_region       => lazy_find(:source_regions, :source_ref => scope[:region]),
+          :subscription        => lazy_find_subscription(scope),
           :orchestration_stack => stack
         )
 

--- a/lib/topological_inventory/amazon/parser/network_adapter.rb
+++ b/lib/topological_inventory/amazon/parser/network_adapter.rb
@@ -26,6 +26,7 @@ module TopologicalInventory::Amazon
             :source_dest_check => interface.source_dest_check,
           },
           :source_region       => lazy_find(:source_regions, :source_ref => scope[:region]),
+          :subscription        => lazy_find_subscription(scope),
           :orchestration_stack => stack,
           :device              => device,
         )

--- a/lib/topological_inventory/amazon/parser/security_group.rb
+++ b/lib/topological_inventory/amazon/parser/security_group.rb
@@ -15,6 +15,7 @@ module TopologicalInventory::Amazon
             :ip_permissions_egress => sg.ip_permissions_egress.map(&:to_h),
           },
           :source_region       => lazy_find(:source_regions, :source_ref => scope[:region]),
+          :subscription        => lazy_find_subscription(scope),
           :orchestration_stack => stack,
           :network             => network,
         )

--- a/lib/topological_inventory/amazon/parser/service_instance.rb
+++ b/lib/topological_inventory/amazon/parser/service_instance.rb
@@ -22,6 +22,7 @@ module TopologicalInventory::Amazon
           :service_offering  => service_offering,
           :service_plan      => service_plan,
           :source_region     => lazy_find(:source_regions, :source_ref => scope[:region]),
+          :subscription      => lazy_find_subscription(scope),
           :extra             => {
             :arn                 => service_instance.arn,
             :type                => service_instance.type,

--- a/lib/topological_inventory/amazon/parser/service_offering.rb
+++ b/lib/topological_inventory/amazon/parser/service_offering.rb
@@ -8,6 +8,7 @@ module TopologicalInventory::Amazon
           :description       => nil,
           :source_created_at => service_offering.created_time,
           :source_region     => lazy_find(:source_regions, :source_ref => scope[:region]),
+          :subscription      => lazy_find_subscription(scope),
           :extra             => {
             :product_view_summary => service_offering.product_view_summary,
             :status               => service_offering.status,

--- a/lib/topological_inventory/amazon/parser/service_plan.rb
+++ b/lib/topological_inventory/amazon/parser/service_plan.rb
@@ -18,6 +18,7 @@ module TopologicalInventory::Amazon
           :source_created_at  => nil,
           :create_json_schema => nil,
           :source_region      => lazy_find(:source_regions, :source_ref => scope[:region]),
+          :subscription       => lazy_find_subscription(scope),
           :extra              => {
             :artifact                         => artifact,
             :launch_path                      => launch_path,

--- a/lib/topological_inventory/amazon/parser/subnet.rb
+++ b/lib/topological_inventory/amazon/parser/subnet.rb
@@ -23,6 +23,7 @@ module TopologicalInventory::Amazon
           },
           :network             => network,
           :source_region       => lazy_find(:source_regions, :source_ref => scope[:region]),
+          :subscription        => lazy_find_subscription(scope),
           :orchestration_stack => stack
         )
 

--- a/lib/topological_inventory/amazon/parser/subscription.rb
+++ b/lib/topological_inventory/amazon/parser/subscription.rb
@@ -1,0 +1,14 @@
+module TopologicalInventory::Amazon
+  class Parser
+    module Subscription
+      def parse_subscriptions(account, _scope)
+        return unless account[:account_id]
+
+        collections[:subscriptions].data <<  TopologicalInventoryIngressApiClient::Subscription.new(
+          :source_ref => account[:account_id],
+          :name       => account[:account_name],
+        )
+      end
+    end
+  end
+end

--- a/lib/topological_inventory/amazon/parser/vm.rb
+++ b/lib/topological_inventory/amazon/parser/vm.rb
@@ -16,6 +16,7 @@ module TopologicalInventory::Amazon
           :flavor               => flavor,
           :mac_addresses        => parse_network(instance)[:mac_addresses],
           :source_region        => lazy_find(:source_regions, :source_ref => scope[:region]),
+          :subscription         => lazy_find_subscription(scope),
           :orchestration_stacks => stack,
         )
 

--- a/lib/topological_inventory/amazon/parser/volume.rb
+++ b/lib/topological_inventory/amazon/parser/volume.rb
@@ -13,6 +13,7 @@ module TopologicalInventory::Amazon
           :size                 => (data.size || 0) * 1024 ** 3,
           :volume_type          => lazy_find(:volume_types, :source_ref => data.volume_type),
           :source_region        => lazy_find(:source_regions, :source_ref => scope[:region]),
+          :subscription         => lazy_find_subscription(scope),
           :orchestration_stacks => stack,
         )
 

--- a/spec/collector_spec.rb
+++ b/spec/collector_spec.rb
@@ -1019,14 +1019,17 @@ RSpec.describe TopologicalInventory::Amazon::Collector do
                               :record_error => nil)
 
     collector = TopologicalInventory::Amazon::Collector.new(
-      "source", "access_key_id", "secret_access_key", metrics
+      "source", "access_key_id", "secret_access_key", nil, metrics
     )
     allow(collector).to receive(:save_inventory).and_return(1)
     allow(collector).to receive(:sweep_inventory)
     allow(collector).to receive(:create_parser).and_return(parser)
 
     with_aws_stubbed(stub_responses) do
-      collector.send(:process_entity, entity)
+      regions = collector.send(:list_regions)
+      accounts = collector.send(:list_accounts)
+
+      collector.send(:process_entity, entity, regions, accounts)
     end
     parser
   end


### PR DESCRIPTION
When providing :sub_account_role parameter, we will go through all accounts under AWS organization and we will attempt to scan each account using the role.

We'll need to expose :sub_account_role to the sources UI and orchestrator