### PR TITLE
Identify RHEL based instances in AWS.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem "prometheus_exporter", "~> 0.4.5"
 gem "rake", ">= 12.3.3"
 gem "rest-client", "~>2.0"
 gem "sources-api-client", "~> 3.0"
-gem "topological_inventory-ingress_api-client", "~> 1.0.1"
+gem "topological_inventory-ingress_api-client", "~> 1.0.4"
 gem "topological_inventory-providers-common", "~> 2.1.5"
 group :test, :development do
   gem "rspec"

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ group :test, :development do
 end
 
 # Collector
-gem "aws-sdk-ec2", "~>1.102.0"
+gem "aws-sdk-ec2", "~>1.209.0"
 gem "aws-sdk-cloudformation", "~>1.25.0"
 gem "aws-sdk-organizations", "~>1.32.0"
 gem "aws-sdk-pricing", "~>1.15.0"

--- a/lib/topological_inventory/amazon/collector/ec2.rb
+++ b/lib/topological_inventory/amazon/collector/ec2.rb
@@ -13,28 +13,12 @@ module TopologicalInventory
           ec2 = ec2_connection(scope)
           instances = ec2.instances
 
-          rhel_images = rhel_images_for_instances(ec2, instances).each_with_object(Hash.new("")) { |img, h| h[img.image_id] = img.platform_details }
-
-          instances.each_with_object([]) do |inst, ary|
-            ary << {:instance => inst, :is_rhel => rhel_images[inst.image_id]}
+          rhel_images = rhel_images_for_instances(ec2, instances).each_with_object(Hash.new("")) do |img, h|
+            h[img.image_id] = img.platform_details
           end
-        end
 
-        def rhel_images_for_instances(ec2, instances)
-          ec2.images(
-            :image_ids => instances.collect(&:image_id).uniq!,
-            :filters   => [
-              {
-                :name   => "platform-details",
-                :values => [
-                  "Red Hat Enterprise Linux",
-                  "Red Hat BYOL Linux"
-                ]
-              }
-            ]
-          )
+          instances.map { |inst| {:instance => inst, :is_rhel => rhel_images[inst.image_id]} }
         end
-        private :rhel_images_for_instances
 
         def availability_zones(scope)
           paginated_query(scope, :ec2_connection, :availability_zones)
@@ -87,6 +71,23 @@ module TopologicalInventory
 
         def reservations(scope)
           paginated_query(scope, :ec2_connection, :reserved_instances)
+        end
+
+        private
+
+        def rhel_images_for_instances(ec2, instances)
+          ec2.images(
+            :image_ids => instances.collect(&:image_id).uniq!,
+            :filters   => [
+              {
+                :name   => "platform-details",
+                :values => [
+                  "Red Hat Enterprise Linux",
+                  "Red Hat BYOL Linux"
+                ]
+              }
+            ]
+          )
         end
       end
     end

--- a/lib/topological_inventory/amazon/collector/ec2.rb
+++ b/lib/topological_inventory/amazon/collector/ec2.rb
@@ -17,7 +17,7 @@ module TopologicalInventory
             h[img.image_id] = img.platform_details
           end
 
-          instances.map { |inst| {:instance => inst, :is_rhel => rhel_images[inst.image_id]} }
+          instances.map { |inst| {:instance => inst, :guest_info => rhel_images[inst.image_id]} }
         end
 
         def availability_zones(scope)

--- a/lib/topological_inventory/amazon/collector/ec2.rb
+++ b/lib/topological_inventory/amazon/collector/ec2.rb
@@ -15,14 +15,14 @@ module TopologicalInventory
 
           rhel_images = rhel_images_for_instances(ec2, instances).each_with_object(Hash.new("")) { |img, h| h[img.image_id] = img.platform_details }
 
-          instances.each_with_object(Array.new) do |inst, ary|
-            ary << { :instance => inst, :is_rhel => rhel_images[inst.image_id] }
+          instances.each_with_object([]) do |inst, ary|
+            ary << {:instance => inst, :is_rhel => rhel_images[inst.image_id]}
           end
         end
 
         def rhel_images_for_instances(ec2, instances)
-          ec2.images({ 
-            :image_ids => instances.collect { |i| i.image_id }.uniq!,
+          ec2.images(
+            :image_ids => instances.collect(&:image_id).uniq!,
             :filters   => [
               {
                 :name   => "platform-details",
@@ -32,7 +32,7 @@ module TopologicalInventory
                 ]
               }
             ]
-          })
+          )
         end
         private :rhel_images_for_instances
 

--- a/lib/topological_inventory/amazon/parser/vm.rb
+++ b/lib/topological_inventory/amazon/parser/vm.rb
@@ -9,8 +9,6 @@ module TopologicalInventory::Amazon
         stack_id = get_from_tags(instance.tags, "aws:cloudformation:stack-id")
         stack    = lazy_find(:orchestration_stacks, :source_ref => stack_id) if stack_id
 
-        puts "**** #{uid} => #{instance_hash[:is_rhel]}"
-
         vm = TopologicalInventoryIngressApiClient::Vm.new(
           :source_ref          => uid,
           :uid_ems             => uid,
@@ -21,6 +19,7 @@ module TopologicalInventory::Amazon
           :source_region       => lazy_find(:source_regions, :source_ref => scope[:region]),
           :subscription        => lazy_find_subscription(scope),
           :orchestration_stack => stack,
+          :guest_info          => instance_hash[:guest_info]
         )
 
         collections[:vms].data << vm

--- a/lib/topological_inventory/amazon/parser/vm.rb
+++ b/lib/topological_inventory/amazon/parser/vm.rb
@@ -1,12 +1,15 @@
 module TopologicalInventory::Amazon
   class Parser
     module Vm
-      def parse_vms(instance, scope)
+      def parse_vms(instance_hash, scope)
+        instance = instance_hash[:instance]
         uid      = instance.id
         name     = get_from_tags(instance.tags, :name) || uid
         flavor   = lazy_find(:flavors, :source_ref => instance.instance_type) if instance.instance_type
         stack_id = get_from_tags(instance.tags, "aws:cloudformation:stack-id")
         stack    = lazy_find(:orchestration_stacks, :source_ref => stack_id) if stack_id
+
+        puts "**** #{uid} => #{instance_hash[:is_rhel]}"
 
         vm = TopologicalInventoryIngressApiClient::Vm.new(
           :source_ref          => uid,

--- a/spec/collector_spec.rb
+++ b/spec/collector_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe TopologicalInventory::Amazon::Collector do
            :name                => "instance_0",
            :orchestration_stack => nil,
            :power_state         => "on",
+           :guest_info          => nil,
            :source_ref          => "instance_0",
            :source_region       =>
                                    {:inventory_collection_name => :source_regions,
@@ -37,6 +38,7 @@ RSpec.describe TopologicalInventory::Amazon::Collector do
            :name                => "instance_ec2_0",
            :orchestration_stack => nil,
            :power_state         => "on",
+           :guest_info          => nil,
            :source_ref          => "instance_ec2_0",
            :source_region       =>
                                    {:inventory_collection_name => :source_regions,
@@ -52,6 +54,7 @@ RSpec.describe TopologicalInventory::Amazon::Collector do
            :name                => "instance_0",
            :orchestration_stack => nil,
            :power_state         => "on",
+           :guest_info          => nil,
            :source_ref          => "instance_0",
            :source_region       =>
                                    {:inventory_collection_name => :source_regions,
@@ -67,6 +70,7 @@ RSpec.describe TopologicalInventory::Amazon::Collector do
            :name                => "instance_ec2_0",
            :orchestration_stack => nil,
            :power_state         => "on",
+           :guest_info          => nil,
            :source_ref          => "instance_ec2_0",
            :source_region       =>
                                    {:inventory_collection_name => :source_regions,


### PR DESCRIPTION
Information collected and passed to the parser. Once the database and ingress API are updated, this can be merged.

Depends on new GEM version based on:
https://github.com/RedHatInsights/topological_inventory-ingress_api-client-ruby/pull/71